### PR TITLE
Fix DESCRIPTION file

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ Suggests:
     Matching,
     optmatch,
     CBPS,
-    WeightIt
+    WeightIt,
     ebal,
     mice,
     knitr,


### PR DESCRIPTION
Currently loading the package gives the following warning:

```
Loading cobalt
Invalid DESCRIPTION:
Malformed Depends or Suggests or Imports or Enhances field.
Offending entries:
  WeightIt
ebal
Entries must be names of packages optionally followed by '<=' or '>=',
white space, and a valid version number in parentheses.

See section 'The DESCRIPTION file' in the 'Writing R Extensions'
manual.
```

This PR fixes that.