### PR TITLE
Convert tests to `testthat`

### DIFF
--- a/tests/testthat/_snaps/bal.tab.md
+++ b/tests/testthat/_snaps/bal.tab.md
@@ -608,3 +608,202 @@
       Matched       185     185
       Unmatched     244       0
 
+# twang
+
+    Code
+      bal.tab(ps.out, thresholds = c(k = 0.05, m = 0.05), stats = "k")
+    Output
+      Balance Measures
+                            Type Diff.ks.max  M.Threshold.ks.max KS.ks.max
+      prop.score.ks.max Distance      0.3907                        0.1651
+      prop.score.es.max Distance      0.5736                        0.2087
+      age                Contin.     -0.0046     Balanced, <0.05    0.0873
+      educ               Contin.     -0.0830 Not Balanced, >0.05    0.0837
+      race_black          Binary      0.0088     Balanced, <0.05    0.0088
+      race_hispan         Binary      0.0057     Balanced, <0.05    0.0057
+      race_white          Binary     -0.0145     Balanced, <0.05    0.0145
+      married             Binary     -0.0127     Balanced, <0.05    0.0127
+      nodegree            Binary      0.0837 Not Balanced, >0.05    0.0837
+      re74               Contin.      0.0491     Balanced, <0.05    0.0436
+      re75               Contin.      0.0594 Not Balanced, >0.05    0.0731
+                        KS.Threshold.ks.max Diff.es.max  M.Threshold.es.max KS.es.max
+      prop.score.ks.max                          0.2371                        0.1243
+      prop.score.es.max                          0.3947                        0.1625
+      age               Not Balanced, >0.05      0.0098     Balanced, <0.05    0.1081
+      educ              Not Balanced, >0.05     -0.0377     Balanced, <0.05    0.0663
+      race_black            Balanced, <0.05     -0.0085     Balanced, <0.05    0.0085
+      race_hispan           Balanced, <0.05      0.0087     Balanced, <0.05    0.0087
+      race_white            Balanced, <0.05     -0.0002     Balanced, <0.05    0.0002
+      married               Balanced, <0.05      0.0136     Balanced, <0.05    0.0136
+      nodegree          Not Balanced, >0.05      0.0407     Balanced, <0.05    0.0407
+      re74                  Balanced, <0.05      0.0920 Not Balanced, >0.05    0.0642
+      re75              Not Balanced, >0.05      0.0904 Not Balanced, >0.05    0.0904
+                        KS.Threshold.es.max
+      prop.score.ks.max                    
+      prop.score.es.max                    
+      age               Not Balanced, >0.05
+      educ              Not Balanced, >0.05
+      race_black            Balanced, <0.05
+      race_hispan           Balanced, <0.05
+      race_white            Balanced, <0.05
+      married               Balanced, <0.05
+      nodegree              Balanced, <0.05
+      re74              Not Balanced, >0.05
+      re75              Not Balanced, >0.05
+      
+      Balance tally for mean differences
+                          ks.max es.max
+      Balanced, <0.05          6      7
+      Not Balanced, >0.05      3      2
+      
+      Variable with the greatest mean difference
+       Weights Variable   Diff         M.Threshold
+        ks.max nodegree 0.0837 Not Balanced, >0.05
+        es.max     re74 0.0920 Not Balanced, >0.05
+      
+      Balance tally for KS statistics
+                          ks.max es.max
+      Balanced, <0.05          5      5
+      Not Balanced, >0.05      4      4
+      
+      Variable with the greatest KS statistic
+       Weights Variable     KS        KS.Threshold
+        ks.max      age 0.0873 Not Balanced, >0.05
+        es.max      age 0.1081 Not Balanced, >0.05
+      
+      Effective sample sizes
+             Control Treated
+      All     429.       185
+      ks.max   27.79     185
+      es.max   18.36     185
+
+---
+
+    Code
+      bal.tab(ps.out.s, un = T)
+    Output
+      Balance Measures
+                      Type Diff.Un Diff.Adj
+      prop.score  Distance  2.5187   0.5047
+      age          Contin. -0.3282   0.0262
+      educ         Contin.  0.0566  -0.0810
+      race_black    Binary  0.6391   0.0265
+      race_hispan   Binary -0.0833  -0.0057
+      race_white    Binary -0.5557  -0.0208
+      married       Binary -0.3282  -0.0317
+      nodegree      Binary  0.0895   0.0938
+      re74         Contin. -0.7810   0.0439
+      re75         Contin. -0.3195   0.0707
+      
+      Effective sample sizes
+                 Control Treated
+      Unadjusted  404.33   174.2
+      Adjusted     30.79   174.2
+
+---
+
+    Code
+      bal.tab(covs, lalonde$treat, weights = get.w(ps.out.s), s.weights = sampw, un = T,
+      distance = ps.out.s$ps)
+    Output
+      Balance Measures
+                      Type Diff.Un Diff.Adj
+      ks.max.ATT  Distance  2.5187   0.5047
+      age          Contin. -0.3282   0.0262
+      educ         Contin.  0.0566  -0.0810
+      race_black    Binary  0.6391   0.0265
+      race_hispan   Binary -0.0833  -0.0057
+      race_white    Binary -0.5557  -0.0208
+      married       Binary -0.3282  -0.0317
+      nodegree      Binary  0.0895   0.0938
+      re74         Contin. -0.7810   0.0439
+      re75         Contin. -0.3195   0.0707
+      
+      Effective sample sizes
+                 Control Treated
+      Unadjusted  404.33   174.2
+      Adjusted     30.79   174.2
+
+# CBPS: binary
+
+    Code
+      bal.tab(cbps.out, disp.bal.tab = T)
+    Output
+      Call
+       CBPS::CBPS(formula = treat ~ log(age) * married + poly(educ, 
+          2) + rms::rcs(age, 3) + race + factor(nodegree) + re74 + 
+          re75, data = lalonde, ATT = F)
+      
+      Balance Measures
+                               Type Diff.Adj
+      prop.score           Distance   0.3034
+      log(age)              Contin.  -0.2423
+      married                Binary  -0.0445
+      poly(educ, 2)_1       Contin.   0.1541
+      poly(educ, 2)_2       Contin.  -0.1199
+      age                   Contin.  -0.2808
+      age'                  Contin.  -0.3300
+      race_black             Binary   0.1115
+      race_hispan            Binary   0.0495
+      race_white             Binary  -0.1610
+      factor(nodegree)       Binary  -0.0255
+      re74                  Contin.  -0.1476
+      re75                  Contin.  -0.0722
+      log(age) * married_0  Contin.   0.0925
+      log(age) * married_1  Contin.  -0.1353
+      
+      Effective sample sizes
+                 Control Treated
+      Unadjusted  429.    185.  
+      Adjusted    236.22   55.85
+
+---
+
+    Code
+      bal.tab(cbps.out, weights = list(exact = (cbps.out.e)), stats = c("m", "v", "k"))
+    Output
+      Call
+       CBPS::CBPS(formula = treat ~ log(age) * married + poly(educ, 
+          2) + rms::rcs(age, 3) + race + factor(nodegree) + re74 + 
+          re75, data = lalonde, ATT = F)
+      
+      Balance Measures
+                               Type Diff.CBPS V.Ratio.CBPS KS.CBPS Diff.exact
+      prop.score           Distance    0.3034       1.0078  0.2115     0.3919
+      log(age)              Contin.   -0.2423       0.6317  0.1624     0.1137
+      married                Binary   -0.0445            .  0.0445    -0.0000
+      poly(educ, 2)_1       Contin.    0.1541       0.6931  0.0859     0.0001
+      poly(educ, 2)_2       Contin.   -0.1199       0.3663  0.0489    -0.2099
+      age                   Contin.   -0.2808       0.5486  0.1624    -0.0001
+      age'                  Contin.   -0.3300       0.4263  0.1624    -0.2149
+      race_black             Binary    0.1115            .  0.1115     0.0000
+      race_hispan            Binary    0.0495            .  0.0495    -0.0000
+      race_white             Binary   -0.1610            .  0.1610    -0.0000
+      factor(nodegree)       Binary   -0.0255            .  0.0255    -0.0000
+      re74                  Contin.   -0.1476       1.3356  0.2519    -0.0001
+      re75                  Contin.   -0.0722       1.2089  0.1458    -0.0000
+      log(age) * married_0  Contin.    0.0925       0.9571  0.0908     0.0577
+      log(age) * married_1  Contin.   -0.1353       0.8808  0.1300    -0.0304
+                           V.Ratio.exact KS.exact
+      prop.score                  1.2278   0.2134
+      log(age)                    0.4792   0.2400
+      married                          .   0.0000
+      poly(educ, 2)_1             0.6962   0.0456
+      poly(educ, 2)_2             0.2881   0.0650
+      age                         0.4323   0.2400
+      age'                        0.3558   0.2400
+      race_black                       .   0.0000
+      race_hispan                      .   0.0000
+      race_white                       .   0.0000
+      factor(nodegree)                 .   0.0000
+      re74                        1.6091   0.2628
+      re75                        1.3902   0.0994
+      log(age) * married_0        1.0987   0.2341
+      log(age) * married_1        0.9407   0.1090
+      
+      Effective sample sizes
+            Control Treated
+      All    429.    185.  
+      CBPS   236.22   55.85
+      exact  280.01   44.21
+

--- a/tests/testthat/_snaps/bal.tab.md
+++ b/tests/testthat/_snaps/bal.tab.md
@@ -1,0 +1,610 @@
+# No adjustment
+
+    Code
+      bal.tab(covs, treat = lalonde$treat, m.threshold = 0.1, v.threshold = 2,
+      imbalanced.only = T)
+    Message
+      Note: 's.d.denom' not specified; assuming pooled.
+    Output
+      Balance Measures
+                    Type Diff.Un     M.Threshold.Un V.Ratio.Un   V.Threshold.Un
+      age        Contin. -0.2419 Not Balanced, >0.1     0.4400 Not Balanced, >2
+      educ       Contin.  0.0448     Balanced, <0.1     0.4959 Not Balanced, >2
+      race_black  Binary  0.6404 Not Balanced, >0.1          .                 
+      race_white  Binary -0.5577 Not Balanced, >0.1          .                 
+      married     Binary -0.3236 Not Balanced, >0.1          .                 
+      nodegree    Binary  0.1114 Not Balanced, >0.1          .                 
+      re74       Contin. -0.5958 Not Balanced, >0.1     0.5181     Balanced, <2
+      re75       Contin. -0.2870 Not Balanced, >0.1     0.9563     Balanced, <2
+      
+      Balance tally for mean differences
+                         count
+      Balanced, <0.1         2
+      Not Balanced, >0.1     7
+      
+      Variable with the greatest mean difference
+         Variable Diff.Un     M.Threshold.Un
+       race_black  0.6404 Not Balanced, >0.1
+      
+      Balance tally for variance ratios
+                       count
+      Balanced, <2         2
+      Not Balanced, >2     2
+      
+      Variable with the greatest variance ratio
+       Variable V.Ratio.Un   V.Threshold.Un
+            age       0.44 Not Balanced, >2
+      
+      Sample sizes
+          Control Treated
+      All     429     185
+
+---
+
+    Code
+      bal.tab(f.build("treat", covs), data = lalonde, ks.threshold = 0.1)
+    Message
+      Note: 's.d.denom' not specified; assuming pooled.
+    Output
+      Balance Measures
+                     Type Diff.Un  KS.Un    KS.Threshold.Un
+      age         Contin. -0.2419 0.1577 Not Balanced, >0.1
+      educ        Contin.  0.0448 0.1114 Not Balanced, >0.1
+      race_black   Binary  0.6404 0.6404 Not Balanced, >0.1
+      race_hispan  Binary -0.0827 0.0827     Balanced, <0.1
+      race_white   Binary -0.5577 0.5577 Not Balanced, >0.1
+      married      Binary -0.3236 0.3236 Not Balanced, >0.1
+      nodegree     Binary  0.1114 0.1114 Not Balanced, >0.1
+      re74        Contin. -0.5958 0.4470 Not Balanced, >0.1
+      re75        Contin. -0.2870 0.2876 Not Balanced, >0.1
+      
+      Balance tally for KS statistics
+                         count
+      Balanced, <0.1         1
+      Not Balanced, >0.1     8
+      
+      Variable with the greatest KS statistic
+         Variable  KS.Un    KS.Threshold.Un
+       race_black 0.6404 Not Balanced, >0.1
+      
+      Sample sizes
+          Control Treated
+      All     429     185
+
+# MatchIt with PS
+
+    Code
+      bal.tab(m1, int = T, v.threshold = 2, imbalanced.only = F)
+    Output
+      Call
+       MatchIt::matchit(formula = treat ~ log(age) * married + educ + 
+          race + nodegree + re74 + re75, data = lalonde, discard = "both", 
+          reestimate = TRUE, replace = T, ratio = 2)
+      
+      Balance Measures
+                                   Type Diff.Adj V.Ratio.Adj      V.Threshold
+      distance                 Distance  -0.0004      0.9889     Balanced, <2
+      log(age)                  Contin.   0.0849      0.4519 Not Balanced, >2
+      married                    Binary   0.0000           .                 
+      educ                      Contin.  -0.0221      0.5851     Balanced, <2
+      race_black                 Binary  -0.0083           .                 
+      race_hispan                Binary  -0.0250           .                 
+      race_white                 Binary   0.0333           .                 
+      nodegree                   Binary   0.0472           .                 
+      re74                      Contin.  -0.0548      1.1790     Balanced, <2
+      re75                      Contin.  -0.0511      1.0739     Balanced, <2
+      log(age) * married_0      Contin.   0.0079      0.9589     Balanced, <2
+      log(age) * married_1      Contin.   0.0089      1.0216     Balanced, <2
+      log(age) * educ           Contin.   0.0456      0.6614     Balanced, <2
+      log(age) * race_black     Contin.  -0.0202      0.9854     Balanced, <2
+      log(age) * race_hispan    Contin.  -0.1001      0.7395     Balanced, <2
+      log(age) * race_white     Contin.   0.1244      1.6089     Balanced, <2
+      log(age) * nodegree_0     Contin.  -0.0970      0.9298     Balanced, <2
+      log(age) * nodegree_1     Contin.   0.1131      0.9089     Balanced, <2
+      log(age) * re74           Contin.  -0.0679      1.0360     Balanced, <2
+      log(age) * re75           Contin.  -0.0356      1.1955     Balanced, <2
+      married_0 * educ          Contin.   0.0050      0.8862     Balanced, <2
+      married_0 * race_black     Binary  -0.0194           .                 
+      married_0 * race_hispan    Binary  -0.0194           .                 
+      married_0 * race_white     Binary   0.0389           .                 
+      married_0 * nodegree_0     Binary   0.0000           .                 
+      married_0 * nodegree_1     Binary   0.0000           .                 
+      married_0 * re74          Contin.  -0.0291      0.8570     Balanced, <2
+      married_0 * re75          Contin.  -0.0675      0.6186     Balanced, <2
+      married_1 * educ          Contin.  -0.0160      0.9128     Balanced, <2
+      married_1 * race_black     Binary   0.0111           .                 
+      married_1 * race_hispan    Binary  -0.0056           .                 
+      married_1 * race_white     Binary  -0.0056           .                 
+      married_1 * nodegree_0     Binary  -0.0472           .                 
+      married_1 * nodegree_1     Binary   0.0472           .                 
+      married_1 * re74          Contin.  -0.0451      1.6016     Balanced, <2
+      married_1 * re75          Contin.  -0.0145      1.3939     Balanced, <2
+      educ * race_black         Contin.  -0.0317      0.8896     Balanced, <2
+      educ * race_hispan        Contin.  -0.1085      0.6776     Balanced, <2
+      educ * race_white         Contin.   0.1031      1.3348     Balanced, <2
+      educ * nodegree_0         Contin.  -0.1320      0.8414     Balanced, <2
+      educ * nodegree_1         Contin.   0.1560      0.9629     Balanced, <2
+      educ * re74               Contin.  -0.0835      1.0430     Balanced, <2
+      educ * re75               Contin.  -0.1052      0.8354     Balanced, <2
+      race_black * nodegree_0    Binary  -0.0528           .                 
+      race_black * nodegree_1    Binary   0.0444           .                 
+      race_black * re74         Contin.  -0.0222      1.2171     Balanced, <2
+      race_black * re75         Contin.  -0.0675      1.0063     Balanced, <2
+      race_hispan * nodegree_0   Binary  -0.0139           .                 
+      race_hispan * nodegree_1   Binary  -0.0111           .                 
+      race_hispan * re74        Contin.  -0.0951      0.6470     Balanced, <2
+      race_hispan * re75        Contin.  -0.0097      1.3203     Balanced, <2
+      race_white * nodegree_0    Binary   0.0194           .                 
+      race_white * nodegree_1    Binary   0.0139           .                 
+      race_white * re74         Contin.  -0.0525      0.6864     Balanced, <2
+      race_white * re75         Contin.   0.0673      2.8908 Not Balanced, >2
+      nodegree_0 * re74         Contin.  -0.0674      1.2444     Balanced, <2
+      nodegree_0 * re75         Contin.  -0.3959      0.3324 Not Balanced, >2
+      nodegree_1 * re74         Contin.  -0.0030      1.0111     Balanced, <2
+      nodegree_1 * re75         Contin.   0.1559      2.6239 Not Balanced, >2
+      re74 * re75               Contin.   0.0520      2.9528 Not Balanced, >2
+      
+      Balance tally for variance ratios
+                       count
+      Balanced, <2        34
+      Not Balanced, >2     5
+      
+      Variable with the greatest variance ratio
+                Variable V.Ratio.Adj      V.Threshold
+       nodegree_0 * re75      0.3324 Not Balanced, >2
+      
+      Sample sizes
+                           Control Treated
+      All                   429.       185
+      Matched (ESS)          67.71     180
+      Matched (Unweighted)  118.       180
+      Unmatched             239.         0
+      Discarded              72.         5
+
+# MatchIt with distance
+
+    Code
+      bal.tab(m1.1, data = lalonde)
+    Output
+      Call
+       MatchIt::matchit(formula = f.build("treat", covs), data = lalonde, 
+          distance = runif(nrow(lalonde)))
+      
+      Balance Measures
+                      Type Diff.Adj
+      distance    Distance   0.0043
+      age          Contin.  -0.2553
+      educ         Contin.   0.0511
+      race_black    Binary   0.5946
+      race_hispan   Binary  -0.0486
+      race_white    Binary  -0.5459
+      married       Binary  -0.2973
+      nodegree      Binary   0.1243
+      re74         Contin.  -0.7496
+      re75         Contin.  -0.2864
+      
+      Sample sizes
+                Control Treated
+      All           429     185
+      Matched       185     185
+      Unmatched     244       0
+
+# MatchIt with complicated formula
+
+    Code
+      bal.tab(m1.2, addl = ~ rms::rcs(educ, 3) + poly(age, 2))
+    Output
+      Call
+       MatchIt::matchit(formula = treat ~ log(age) * married + poly(educ, 
+          2) + rms::rcs(age, 3) + race + factor(nodegree) + re74 + 
+          re75, data = lalonde, replace = T, ratio = 2)
+      
+      Balance Measures
+                           Type Diff.Adj
+      distance         Distance   0.0014
+      log(age)          Contin.   0.0496
+      married            Binary   0.0757
+      poly(educ, 2)_1   Contin.   0.0094
+      poly(educ, 2)_2   Contin.   0.0613
+      age               Contin.  -0.0011
+      age'              Contin.  -0.1261
+      race_black         Binary  -0.0135
+      race_hispan        Binary  -0.0081
+      race_white         Binary   0.0216
+      factor(nodegree)   Binary   0.0108
+      re74              Contin.   0.1383
+      re75              Contin.   0.1371
+      educ'             Contin.   0.0102
+      poly(age, 2)_2    Contin.  -0.2459
+      
+      Sample sizes
+                           Control Treated
+      All                   429.       185
+      Matched (ESS)          36.88     185
+      Matched (Unweighted)  108.       185
+      Unmatched             321.         0
+
+# MatchIt with Malahanobis
+
+    Code
+      bal.tab(m2, data = lalonde, int = T, v.threshold = 2, addl = "race")
+    Output
+      Call
+       MatchIt::matchit(formula = f.build("treat", covs), data = lalonde, 
+          distance = "mahalanobis")
+      
+      Balance Measures
+                                  Type Diff.Adj V.Ratio.Adj      V.Threshold
+      age                      Contin.   0.1254      0.5333     Balanced, <2
+      educ                     Contin.  -0.0457      0.8306     Balanced, <2
+      race_black                Binary   0.3784           .                 
+      race_hispan               Binary   0.0000           .                 
+      race_white                Binary  -0.3784           .                 
+      married                   Binary  -0.0595           .                 
+      nodegree                  Binary   0.0486           .                 
+      re74                     Contin.  -0.2482      0.8710     Balanced, <2
+      re75                     Contin.  -0.1331      1.0081     Balanced, <2
+      age * educ               Contin.   0.0776      0.6363     Balanced, <2
+      age * race_black         Contin.   0.8498      0.6054     Balanced, <2
+      age * race_hispan        Contin.   0.0118      1.1057     Balanced, <2
+      age * race_white         Contin.  -1.1167      0.3474 Not Balanced, >2
+      age * married_0          Contin.   0.2640      0.8431     Balanced, <2
+      age * married_1          Contin.  -0.1814      0.7026     Balanced, <2
+      age * nodegree_0         Contin.  -0.0995      0.8893     Balanced, <2
+      age * nodegree_1         Contin.   0.1654      0.8485     Balanced, <2
+      age * re74               Contin.  -0.3121      0.5767     Balanced, <2
+      age * re75               Contin.  -0.1297      1.0007     Balanced, <2
+      educ * race_black        Contin.   0.9414      0.6058     Balanced, <2
+      educ * race_hispan       Contin.  -0.0023      0.9786     Balanced, <2
+      educ * race_white        Contin.  -1.2219      0.3613 Not Balanced, >2
+      educ * married_0         Contin.   0.1279      0.8115     Balanced, <2
+      educ * married_1         Contin.  -0.1580      0.7993     Balanced, <2
+      educ * nodegree_0        Contin.  -0.1147      0.8939     Balanced, <2
+      educ * nodegree_1        Contin.   0.1238      0.9564     Balanced, <2
+      educ * re74              Contin.  -0.2464      0.8729     Balanced, <2
+      educ * re75              Contin.  -0.1636      0.9095     Balanced, <2
+      race_black * married_0    Binary   0.3514           .                 
+      race_black * married_1    Binary   0.0270           .                 
+      race_black * nodegree_0   Binary   0.0649           .                 
+      race_black * nodegree_1   Binary   0.3135           .                 
+      race_black * re74        Contin.   0.0738      1.4717     Balanced, <2
+      race_black * re75        Contin.   0.1283      1.6861     Balanced, <2
+      race_hispan * married_0   Binary   0.0000           .                 
+      race_hispan * married_1   Binary   0.0000           .                 
+      race_hispan * nodegree_0  Binary   0.0000           .                 
+      race_hispan * nodegree_1  Binary   0.0000           .                 
+      race_hispan * re74       Contin.   0.0125      2.3313 Not Balanced, >2
+      race_hispan * re75       Contin.   0.0429      1.3644     Balanced, <2
+      race_white * married_0    Binary  -0.2919           .                 
+      race_white * married_1    Binary  -0.0865           .                 
+      race_white * nodegree_0   Binary  -0.1135           .                 
+      race_white * nodegree_1   Binary  -0.2649           .                 
+      race_white * re74        Contin.  -1.7053      0.0495 Not Balanced, >2
+      race_white * re75        Contin.  -1.1031      0.1021 Not Balanced, >2
+      married_0 * nodegree_0    Binary   0.0054           .                 
+      married_0 * nodegree_1    Binary   0.0541           .                 
+      married_0 * re74         Contin.  -0.1213      0.8948     Balanced, <2
+      married_0 * re75         Contin.  -0.0188      1.0963     Balanced, <2
+      married_1 * nodegree_0    Binary  -0.0541           .                 
+      married_1 * nodegree_1    Binary  -0.0054           .                 
+      married_1 * re74         Contin.  -0.2140      0.7090     Balanced, <2
+      married_1 * re75         Contin.  -0.1377      0.8936     Balanced, <2
+      nodegree_0 * re74        Contin.  -0.2048      0.7711     Balanced, <2
+      nodegree_0 * re75        Contin.  -0.3461      0.3803 Not Balanced, >2
+      nodegree_1 * re74        Contin.  -0.1269      0.8231     Balanced, <2
+      nodegree_1 * re75        Contin.   0.0401      1.5570     Balanced, <2
+      re74 * re75              Contin.  -0.0904      1.1162     Balanced, <2
+      
+      Balance tally for variance ratios
+                       count
+      Balanced, <2        32
+      Not Balanced, >2     6
+      
+      Variable with the greatest variance ratio
+                Variable V.Ratio.Adj      V.Threshold
+       race_white * re74      0.0495 Not Balanced, >2
+      
+      Sample sizes
+                Control Treated
+      All           429     185
+      Matched       185     185
+      Unmatched     244       0
+
+# MatchIt with subclassification
+
+    Code
+      bal.tab(m3, int = F, v.threshold = 2, disp.subclass = T, ks.threshold = 0.1)
+    Output
+      Call
+       MatchIt::matchit(formula = f.build("treat", covs), data = lalonde, 
+          method = "subclass")
+      
+      Balance by subclass
+       - - - Subclass 1 - - - 
+                      Type Diff.Adj V.Ratio.Adj  V.Threshold KS.Adj
+      distance    Distance   0.2785      1.5087              0.4866
+      age          Contin.  -0.4024      0.4163 Balanced, <2 0.1600
+      educ         Contin.   0.1142      0.5625 Balanced, <2 0.0959
+      race_black    Binary   0.0823           .              0.0823
+      race_hispan   Binary   0.1492           .              0.1492
+      race_white    Binary  -0.2315           .              0.2315
+      married       Binary  -0.2877           .              0.2877
+      nodegree      Binary  -0.0003           .              0.0003
+      re74         Contin.  -0.5864      1.1631 Balanced, <2 0.4293
+      re75         Contin.  -0.1729      1.0676 Balanced, <2 0.2623
+                        KS.Threshold
+      distance                      
+      age         Not Balanced, >0.1
+      educ            Balanced, <0.1
+      race_black      Balanced, <0.1
+      race_hispan Not Balanced, >0.1
+      race_white  Not Balanced, >0.1
+      married     Not Balanced, >0.1
+      nodegree        Balanced, <0.1
+      re74        Not Balanced, >0.1
+      re75        Not Balanced, >0.1
+      
+       - - - Subclass 2 - - - 
+                      Type Diff.Adj V.Ratio.Adj  V.Threshold KS.Adj
+      distance    Distance   0.1873      1.3761              0.3858
+      age          Contin.  -0.7473      0.3404 Balanced, <2 0.4220
+      educ         Contin.   0.1183      0.6596 Balanced, <2 0.1035
+      race_black    Binary   0.0094           .              0.0094
+      race_hispan   Binary  -0.0094           .              0.0094
+      race_white    Binary   0.0000           .              0.0000
+      married       Binary  -0.2473           .              0.2473
+      nodegree      Binary  -0.0121           .              0.0121
+      re74         Contin.  -0.0352      0.9023 Balanced, <2 0.1882
+      re75         Contin.  -0.0970      0.9876 Balanced, <2 0.2325
+                        KS.Threshold
+      distance                      
+      age         Not Balanced, >0.1
+      educ        Not Balanced, >0.1
+      race_black      Balanced, <0.1
+      race_hispan     Balanced, <0.1
+      race_white      Balanced, <0.1
+      married     Not Balanced, >0.1
+      nodegree        Balanced, <0.1
+      re74        Not Balanced, >0.1
+      re75        Not Balanced, >0.1
+      
+       - - - Subclass 3 - - - 
+                      Type Diff.Adj V.Ratio.Adj  V.Threshold KS.Adj
+      distance    Distance  -0.0140      1.0943              0.1197
+      age          Contin.   0.0524      0.4654 Balanced, <2 0.2677
+      educ         Contin.   0.1372      0.3845 Balanced, <2 0.2191
+      race_black    Binary   0.0000           .              0.0000
+      race_hispan   Binary   0.0000           .              0.0000
+      race_white    Binary   0.0000           .              0.0000
+      married       Binary   0.3550           .              0.3550
+      nodegree      Binary   0.2191           .              0.2191
+      re74         Contin.  -0.2669      0.2635 Balanced, <2 0.3225
+      re75         Contin.  -0.0970      0.6585 Balanced, <2 0.1460
+                        KS.Threshold
+      distance                      
+      age         Not Balanced, >0.1
+      educ        Not Balanced, >0.1
+      race_black      Balanced, <0.1
+      race_hispan     Balanced, <0.1
+      race_white      Balanced, <0.1
+      married     Not Balanced, >0.1
+      nodegree    Not Balanced, >0.1
+      re74        Not Balanced, >0.1
+      re75        Not Balanced, >0.1
+      
+       - - - Subclass 4 - - - 
+                      Type Diff.Adj V.Ratio.Adj      V.Threshold KS.Adj
+      distance    Distance  -0.0003      1.4231                  0.1860
+      age          Contin.  -0.0499      0.2048     Balanced, <2 0.2902
+      educ         Contin.  -0.1436      1.0063     Balanced, <2 0.1711
+      race_black    Binary   0.0000           .                  0.0000
+      race_hispan   Binary   0.0000           .                  0.0000
+      race_white    Binary   0.0000           .                  0.0000
+      married       Binary  -0.1116           .                  0.1116
+      nodegree      Binary  -0.0417           .                  0.0417
+      re74         Contin.  -0.0073      2.2051 Not Balanced, >2 0.3051
+      re75         Contin.  -0.0801      1.7074     Balanced, <2 0.2902
+                        KS.Threshold
+      distance                      
+      age         Not Balanced, >0.1
+      educ        Not Balanced, >0.1
+      race_black      Balanced, <0.1
+      race_hispan     Balanced, <0.1
+      race_white      Balanced, <0.1
+      married     Not Balanced, >0.1
+      nodegree        Balanced, <0.1
+      re74        Not Balanced, >0.1
+      re75        Not Balanced, >0.1
+      
+       - - - Subclass 5 - - - 
+                      Type Diff.Adj V.Ratio.Adj      V.Threshold KS.Adj
+      distance    Distance  -0.0224      0.7370                  0.2832
+      age          Contin.   0.2640      0.7413     Balanced, <2 0.2885
+      educ         Contin.  -0.2977      0.5077     Balanced, <2 0.1774
+      race_black    Binary   0.0000           .                  0.0000
+      race_hispan   Binary   0.0000           .                  0.0000
+      race_white    Binary   0.0000           .                  0.0000
+      married       Binary   0.0000           .                  0.0000
+      nodegree      Binary   0.0376           .                  0.0376
+      re74         Contin.   0.0190      2.3025 Not Balanced, >2 0.1398
+      re75         Contin.   0.1233      4.2576 Not Balanced, >2 0.1613
+                        KS.Threshold
+      distance                      
+      age         Not Balanced, >0.1
+      educ        Not Balanced, >0.1
+      race_black      Balanced, <0.1
+      race_hispan     Balanced, <0.1
+      race_white      Balanced, <0.1
+      married         Balanced, <0.1
+      nodegree        Balanced, <0.1
+      re74        Not Balanced, >0.1
+      re75        Not Balanced, >0.1
+      
+       - - - Subclass 6 - - - 
+                      Type Diff.Adj V.Ratio.Adj      V.Threshold KS.Adj
+      distance    Distance   0.0143      2.8080                  0.3441
+      age          Contin.   0.5245      0.4039     Balanced, <2 0.6022
+      educ         Contin.   0.2781      6.1419 Not Balanced, >2 0.1398
+      race_black    Binary   0.0000           .                  0.0000
+      race_hispan   Binary   0.0000           .                  0.0000
+      race_white    Binary   0.0000           .                  0.0000
+      married       Binary   0.0000           .                  0.0000
+      nodegree      Binary  -0.1290           .                  0.1290
+      re74         Contin.  -0.0152      1.3924     Balanced, <2 0.2043
+      re75         Contin.  -0.2407      2.6542 Not Balanced, >2 0.7419
+                        KS.Threshold
+      distance                      
+      age         Not Balanced, >0.1
+      educ        Not Balanced, >0.1
+      race_black      Balanced, <0.1
+      race_hispan     Balanced, <0.1
+      race_white      Balanced, <0.1
+      married         Balanced, <0.1
+      nodegree    Not Balanced, >0.1
+      re74        Not Balanced, >0.1
+      re75        Not Balanced, >0.1
+      
+
+# MatchIt: full matching
+
+    Code
+      bal.tab(m4, int = T, ks.threshold = 0.05)
+    Output
+      Call
+       MatchIt::matchit(formula = f.build("treat", covs), data = lalonde, 
+          method = "full", distance = "glm", link = "probit", estimand = "ATE")
+      
+      Balance Measures
+                                   Type Diff.Adj KS.Adj        KS.Threshold
+      distance                 Distance   0.0043 0.0987                    
+      age                       Contin.  -0.1864 0.2046 Not Balanced, >0.05
+      educ                      Contin.   0.1588 0.1016 Not Balanced, >0.05
+      race_black                 Binary   0.0029 0.0029     Balanced, <0.05
+      race_hispan                Binary  -0.0015 0.0015     Balanced, <0.05
+      race_white                 Binary  -0.0014 0.0014     Balanced, <0.05
+      married                    Binary  -0.0045 0.0045     Balanced, <0.05
+      nodegree                   Binary  -0.1016 0.1016 Not Balanced, >0.05
+      re74                      Contin.  -0.2312 0.2455 Not Balanced, >0.05
+      re75                      Contin.  -0.2711 0.2308 Not Balanced, >0.05
+      age * educ                Contin.  -0.0290 0.1442 Not Balanced, >0.05
+      age * race_black          Contin.   0.0288 0.1064 Not Balanced, >0.05
+      age * race_hispan         Contin.  -0.0658 0.0439     Balanced, <0.05
+      age * race_white          Contin.  -0.1170 0.1314 Not Balanced, >0.05
+      age * married_0           Contin.   0.0260 0.1961 Not Balanced, >0.05
+      age * married_1           Contin.  -0.1354 0.1393 Not Balanced, >0.05
+      age * nodegree_0          Contin.   0.1473 0.1671 Not Balanced, >0.05
+      age * nodegree_1          Contin.  -0.2570 0.1238 Not Balanced, >0.05
+      age * re74                Contin.  -0.3229 0.2455 Not Balanced, >0.05
+      age * re75                Contin.  -0.2871 0.2236 Not Balanced, >0.05
+      educ * race_black         Contin.   0.0014 0.0216     Balanced, <0.05
+      educ * race_hispan        Contin.   0.0155 0.0247     Balanced, <0.05
+      educ * race_white         Contin.   0.0755 0.1218 Not Balanced, >0.05
+      educ * married_0          Contin.  -0.0054 0.0517 Not Balanced, >0.05
+      educ * married_1          Contin.   0.0867 0.1245 Not Balanced, >0.05
+      educ * nodegree_0         Contin.   0.1901 0.1016 Not Balanced, >0.05
+      educ * nodegree_1         Contin.  -0.1651 0.0974 Not Balanced, >0.05
+      educ * re74               Contin.  -0.1654 0.2405 Not Balanced, >0.05
+      educ * re75               Contin.  -0.2567 0.2482 Not Balanced, >0.05
+      race_black * married_0     Binary  -0.0066 0.0066     Balanced, <0.05
+      race_black * married_1     Binary   0.0096 0.0096     Balanced, <0.05
+      race_black * nodegree_0    Binary  -0.0146 0.0146     Balanced, <0.05
+      race_black * nodegree_1    Binary   0.0176 0.0176     Balanced, <0.05
+      race_black * re74         Contin.   0.0328 0.0770 Not Balanced, >0.05
+      race_black * re75         Contin.   0.0007 0.0683 Not Balanced, >0.05
+      race_hispan * married_0    Binary   0.0150 0.0150     Balanced, <0.05
+      race_hispan * married_1    Binary  -0.0165 0.0165     Balanced, <0.05
+      race_hispan * nodegree_0   Binary  -0.0056 0.0056     Balanced, <0.05
+      race_hispan * nodegree_1   Binary   0.0040 0.0040     Balanced, <0.05
+      race_hispan * re74        Contin.  -0.1263 0.0485     Balanced, <0.05
+      race_hispan * re75        Contin.  -0.1024 0.0434     Balanced, <0.05
+      race_white * married_0     Binary  -0.0038 0.0038     Balanced, <0.05
+      race_white * married_1     Binary   0.0024 0.0024     Balanced, <0.05
+      race_white * nodegree_0    Binary   0.1218 0.1218 Not Balanced, >0.05
+      race_white * nodegree_1    Binary  -0.1231 0.1231 Not Balanced, >0.05
+      race_white * re74         Contin.  -0.2602 0.1387 Not Balanced, >0.05
+      race_white * re75         Contin.  -0.3474 0.1716 Not Balanced, >0.05
+      married_0 * nodegree_0     Binary   0.0190 0.0190     Balanced, <0.05
+      married_0 * nodegree_1     Binary  -0.0144 0.0144     Balanced, <0.05
+      married_0 * re74          Contin.  -0.0453 0.1208 Not Balanced, >0.05
+      married_0 * re75          Contin.  -0.0836 0.1320 Not Balanced, >0.05
+      married_1 * nodegree_0     Binary   0.0826 0.0826 Not Balanced, >0.05
+      married_1 * nodegree_1     Binary  -0.0871 0.0871 Not Balanced, >0.05
+      married_1 * re74          Contin.  -0.2223 0.1322 Not Balanced, >0.05
+      married_1 * re75          Contin.  -0.2402 0.1683 Not Balanced, >0.05
+      nodegree_0 * re74         Contin.   0.0055 0.0963 Not Balanced, >0.05
+      nodegree_0 * re75         Contin.  -0.2082 0.1340 Not Balanced, >0.05
+      nodegree_1 * re74         Contin.  -0.3151 0.2519 Not Balanced, >0.05
+      nodegree_1 * re75         Contin.  -0.1537 0.1878 Not Balanced, >0.05
+      re74 * re75               Contin.  -0.1808 0.1970 Not Balanced, >0.05
+      
+      Balance tally for KS statistics
+                          count
+      Balanced, <0.05        21
+      Not Balanced, >0.05    38
+      
+      Variable with the greatest KS statistic
+                Variable KS.Adj        KS.Threshold
+       nodegree_1 * re74 0.2519 Not Balanced, >0.05
+      
+      Sample sizes
+                           Control Treated
+      All                    429.   185.  
+      Matched (ESS)          257.3   24.68
+      Matched (Unweighted)   429.   185.  
+
+---
+
+    Code
+      bal.tab(m4, pairwise = FALSE, un = T)
+    Output
+      Call
+       MatchIt::matchit(formula = f.build("treat", covs), data = lalonde, 
+          method = "full", distance = "glm", link = "probit", estimand = "ATE")
+      
+      Balance summary across all treatment pairs
+                      Type Max.Diff.Un Max.Diff.Adj
+      distance    Distance      1.2347       0.0033
+      age          Contin.      0.1690       0.2023
+      educ         Contin.      0.0313       0.1712
+      race_black    Binary      0.4475       0.0016
+      race_hispan   Binary      0.0578       0.0049
+      race_white    Binary      0.3897       0.0046
+      married       Binary      0.2261       0.0126
+      nodegree      Binary      0.0778       0.1110
+      re74         Contin.      0.4162       0.2329
+      re75         Contin.      0.2005       0.2630
+      
+      Sample sizes
+                           Control Treated
+      All                    429.   185.  
+      Matched (ESS)          257.3   24.68
+      Matched (Unweighted)   429.   185.  
+
+# MatchIt: genetic matching, using matching weights
+
+    Code
+      bal.tab(m5, method = "m", estimand = "ATT")
+    Output
+      Call
+       MatchIt::matchit(formula = f.build("treat", covs), data = lalonde, 
+          method = "genetic", replace = F, ratio = 1, pop.size = 50)
+      
+      Balance Measures
+                      Type Diff.Adj
+      distance    Distance   1.0083
+      age          Contin.  -0.0272
+      educ         Contin.   0.0941
+      race_black    Binary   0.3730
+      race_hispan   Binary  -0.2216
+      race_white    Binary  -0.1514
+      married       Binary  -0.1081
+      nodegree      Binary   0.0649
+      re74         Contin.  -0.1967
+      re75         Contin.  -0.0866
+      
+      Sample sizes
+                Control Treated
+      All           429     185
+      Matched       185     185
+      Unmatched     244       0
+

--- a/tests/testthat/test-bal.tab.R
+++ b/tests/testthat/test-bal.tab.R
@@ -85,6 +85,7 @@ test_that("MatchIt with subclassification", {
 
 test_that("MatchIt: full matching", {
     skip_if_not_installed("MatchIt")
+    skip_if_not_installed("optmatch")
     m4 <- MatchIt::matchit(f.build("treat", covs), data = lalonde, method = "full", distance = "glm", link = "probit", estimand = "ATE")
     expect_snapshot(
         bal.tab(m4, int = T, ks.threshold = .05)
@@ -97,9 +98,434 @@ test_that("MatchIt: full matching", {
 test_that("MatchIt: genetic matching, using matching weights", {
     skip_if_not_installed("MatchIt")
     skip_if_not_installed("rgenoud")
+    skip_if_not_installed("Matching")
     m5 <- MatchIt::matchit(f.build("treat", covs), data = lalonde, method = "genetic", replace = F,
                   ratio = 1, pop.size = 50)
    expect_snapshot(
        bal.tab(m5, method = "m", estimand = "ATT")
    )
 })
+
+test_that("twang", {
+    skip_if_not_installed("twang")
+    set.seed(123)
+    ps.out <- twang::ps(f.build("treat", covs), data = lalonde, 
+                 stop.method = c("ks.max", "es.max"), 
+                 estimand = "ATT", verbose = FALSE, n.trees = 2000, bag.fraction = .6)
+    sampw <- sample(c(1.25, 0.75), nrow(covs), TRUE, c(.5, .5))
+    ps.out.s <- twang::ps(f.build("treat", covs), data = lalonde, 
+                   stop.method = c("ks.max"), 
+                   estimand = "ATT", verbose = FALSE,
+                   sampw = sampw, n.trees = 1000)
+    
+    
+    expect_snapshot(
+        bal.tab(ps.out, thresholds = c(k=.05, m = .05), stats = "k")
+    )
+    expect_snapshot(
+        bal.tab(ps.out.s, un = T)
+    )
+    expect_snapshot(
+        bal.tab(covs, lalonde$treat, weights = get.w(ps.out.s), s.weights = sampw,
+                un = T, distance = ps.out.s$ps)
+    )
+})
+
+test_that("CBPS: binary", {
+    skip_if_not_installed("CBPS")
+    skip_if_not_installed("rms")
+    cbps.out <- CBPS::CBPS(treat ~ log(age)*married + poly(educ,2) + rms::rcs(age,3) + race + factor(nodegree) + re74 + re75, data = lalonde, ATT = F)
+cbps.out.e <- CBPS::CBPS(f.build("treat", covs), data = lalonde, method = "exact", ATT = F)
+
+    expect_snapshot(
+        bal.tab(cbps.out, disp.bal.tab = T)
+    )
+    
+    expect_snapshot(
+        bal.tab(cbps.out, weights = list("exact" = (cbps.out.e)), stats = c("m", "v", "k"))
+    )
+})
+
+
+# #Matching
+# library("Matching")
+# p.score <- glm(f.build("treat", covs), 
+#                data = lalonde, family = "binomial")$fitted.values
+# Match.out <- Match(Tr = lalonde$treat, X = p.score, estimand = "ATE",
+#                    M = 1, replace = T, CommonSupport = F)
+# bal.tab(Match.out, formula = f.build("treat", covs), data = lalonde)
+# gen <- GenMatch(Tr = lalonde$treat, X = covs_,
+#                 M = 1, replace = F, pop.size = 10, 
+#                 print.level = 0, ties = F)
+# Gen.Match.out <- Match(Tr=lalonde$treat, X=covs_, Weight.matrix=gen,
+#                        M = 2, replace = F, ties = F)
+# bal.tab(Gen.Match.out, formula = f.build("treat", covs), data = lalonde,
+#         addl = data.frame(age2 = covs$age^2))
+# gen2 <- GenMatch(Tr = lalonde$treat, X = covs_,
+#                  M = 1, replace = F, pop.size = 1000, 
+#                  print.level = 0, ties = F, BalanceMatrix = cbind(covs_, age2 = covs_$age^2))
+# Gen.Match.out2 <- Match(Tr=lalonde$treat, X=covs_, Weight.matrix=gen2,
+#                         M = 1, replace = F, ties = F)
+# bal.tab(Gen.Match.out2, formula = f.build("treat", covs), data = lalonde,
+#         addl = data.frame(age2 = covs$age^2))
+# 
+# Matchby.out <- Matchby(Tr = lalonde$treat, X = p.score, by = lalonde$married)
+# bal.tab(Matchby.out, formula = f.build("treat", covs), data = lalonde,
+#         addl = ~I(age^2) + married*race)
+# 
+# #optmatch
+# library("optmatch")
+# ls <- lalonde[sample(1:614, 614, F),]
+# p.score <- glm(treat ~ age + educ + race + 
+#                    married + nodegree + re74 + re75, 
+#                data = ls, family = binomial)$fitted.values
+# pm <- pairmatch(treat ~ qlogis(p.score), data = ls)
+# 
+# ## Using formula and data (treatment not needed)
+# bal.tab(pm,  ~ age + educ + race + 
+#             married + nodegree + re74 + re75, data = ls,
+#         distance = p.score)
+# 
+# #WeightIt
+# library(WeightIt)
+# W <- weightit(treat ~ log(age)*married + poly(educ,2) + rms::rcs(age,3) + race + factor(nodegree) + re74 + re75, data = lalonde,
+#               method = "ps", estimand = "ATT")
+# bal.tab(W)
+# W.cont <- weightit(f.build("re75", covs[-7]), data = lalonde,
+#                    method = "ebal")
+# bal.tab(W.cont, stats = c("c", "ks"), disp = "means", un = T)
+# W.mult <- weightit(f.build("race", covs[-3]), data = lalonde,
+#                    method = "ps", estimand = "ATE",
+#                    focal = "black")
+# bal.tab(W.mult, disp = c("m", "sds"), which.treat = .all)
+# 
+# #Data frame/formula: weighting
+# glm1 <- glm(treat ~ age + educ + race, data = lalonde, 
+#             family = "binomial")
+# lalonde$distance <- glm1$fitted.values
+# lalonde$iptw.weights <- ifelse(lalonde$treat==1, 
+#                                1/lalonde$distance, 
+#                                1/(1-lalonde$distance))
+# bal.tab(f.build("treat", covs), data = lalonde, 
+#         weights = "iptw.weights", method = "weighting", 
+#         addl = data.frame(age2 = covs$age^2),
+#         distance = "distance")
+# #Data frame/formula: subclassification
+# lalonde$subclass <- findInterval(lalonde$distance, 
+#                                  quantile(lalonde$distance, (0:6)/6), all.inside = T)
+# 
+# bal.tab(covs, treat = lalonde$treat, subclass = lalonde$subclass, 
+#         disp.subclass = TRUE, addl = ~I(age^2),
+#         m.threshold = .1, v.threshold = 2)
+# 
+# bal.tab(covs, treat = lalonde$re75, subclass = lalonde$subclass, 
+#         disp.subclass = TRUE, addl = ~I(age^2))
+# 
+# #Entropy balancing
+# library("ebal")
+# e.out <- ebalance(lalonde$treat, cbind(covs_[,-3], age_2 = covs_$age^2, re74_2 = covs_$re74^2/1000, 
+#                                        re75_2 = covs_$re75^2/1000, educ_2 = covs_$educ^2))
+# bal.tab(e.out, treat = lalonde$treat, covs = covs, disp.ks = T, disp.v.ratio = T)
+# e.out.trim <- ebalance.trim(e.out)
+# bal.tab(e.out.trim, treat = lalonde$treat, covs = covs, disp.ks = T, disp.v.ratio = T)
+# bal.tab(covs, lalonde$treat, weights = list(e = e.out,
+#                                             e.trim = e.out.trim),
+#         disp.ks = T, disp.v.ratio = T)
+# #Continuous treatment (CBPS)
+# cbps.out2 <- CBPS(f.build("re78", covs), data = lalonde, method = "exact")
+# bal.tab(cbps.out2, stats = c("c", "sp"))
+# cbps.out2.e <- CBPS(f.build("re78", covs), data = do.call(data.frame, lapply(lalonde, rank)), method = "exact")
+# bal.tab(cbps.out2, weights = list(CBPS.sp = cbps.out2.e),
+#         stats = c("c", "sp"))
+# #Clustering with MatchIt
+# lalonde$school <- sample(LETTERS[1:4], nrow(lalonde), replace = T)
+# m5 <- matchit(f.build("treat", covs), data = lalonde, exact = "school")
+# bal.tab(m5, cluster = lalonde$school, disp.v.ratio = T, cluster.summary = T)
+# bal.tab(m5, cluster = lalonde$school, disp.ks = T, abs = T, cluster.fun = c("max"))
+# #Clustering w/ continuous treatment
+# bal.tab(cbps.out2, cluster = lalonde$school, un = T, cluster.fun = "mean")
+# #Multiple imputation
+# data("lalonde_mis", package = "cobalt")
+# covs_mis <- subset(lalonde_mis, select = -c(re78, treat))
+# lalonde_mis_ <- splitfactor(lalonde_mis, "race")
+# covs_mis_ <- subset(lalonde_mis_, select = -c(re78, treat))
+# 
+# library("mice")
+# imp <- mice(lalonde_mis, m = 3)
+# imp.data <- complete(imp, "long", include = FALSE)
+# imp.data <- imp.data[with(imp.data, order(.imp, .id)),]
+# 
+# ps <- match.weight <- rep(0, nrow(imp.data))
+# for (i in unique(imp.data$.imp)) {
+#     in.imp <- imp.data$.imp == i
+#     ps[in.imp] <- glm(f.build("treat", covs_mis), data = imp.data[in.imp,], 
+#                       family = "binomial")$fitted.values
+#     m.out <- matchit(treat ~ age, data = imp.data[in.imp,], distance = ps[in.imp])
+#     match.weight[in.imp] <- m.out$weights
+# }
+# imp.data <- cbind(imp.data, ps = ps, match.weight = match.weight)
+# 
+# bal.tab(f.build("treat", covs_mis), data = imp.data, weights = "match.weight", 
+#         method = "matching", imp = ".imp", distance = "ps", which.imp = .all,
+#         disp.ks = T)
+# 
+# bal.tab(f.build("treat", covs_mis), data = imp, weights = match.weight, 
+#         method = "matching", distance = ps, which.imp = NULL,
+#         cluster = "race", disp.v = T, abs = T, which.cluster = "black")
+# 
+# #With WeightIt
+# library(WeightIt)
+# W.imp <- weightit(f.build("treat", covs_mis), data = imp.data, estimand = "ATT",
+#                   by = ".imp", method = "optweight", moments = 2)
+# bal.tab(W.imp, imp = ".imp", disp.v.ratio = TRUE, abs = F)
+# 
+# #With MatchThem
+# library(MatchThem)
+# mt.out <- matchthem(f.build("treat", covs_mis), datasets = imp,
+#                     approach = "within")
+# bal.tab(mt.out)
+# 
+# wt.out <- weightthem(f.build("race", covs_mis[-3]), datasets = imp,
+#                      approach = "within", method = "optweight")
+# bal.tab(wt.out)
+# 
+# #With continuous treatment
+# imp.data <- complete(imp, "long", include = FALSE)
+# imp.data <- imp.data[with(imp.data, order(.imp, .id)),]
+# w <- rep(0, nrow(imp.data))
+# for (i in unique(imp.data$.imp)) {
+#     in.imp <- imp.data$.imp == i
+#     w[in.imp] <- get.w(CBPS(f.build("re78", covs_mis), data = imp.data[in.imp,],
+#                             method = "exact"))
+# }
+# imp.data <- cbind(imp.data, cbps.w = w)
+# bal.tab(f.build("re78", covs_mis), data = imp, weights = w, 
+#         which.imp = .all, un = T, thresholds = .1)
+# 
+# bal.tab(f.build("re78", covs_mis), data = imp.data, weights = "cbps.w", 
+#         method = "w", imp = ".imp", which.imp = NULL, cluster = "race")
+# 
+# #Missingness indicators
+# data("lalonde_mis", package = "cobalt")
+# covs_mis <- subset(lalonde_mis, select = -c(re78, treat))
+# lalonde_mis_ <- splitfactor(lalonde_mis, "race")
+# covs_mis_ <- subset(lalonde_mis_, select = -c(re78, treat))
+# library(twang)
+# 
+# ps.out <- ps(f.build("treat", covs_mis), data = lalonde_mis, 
+#              stop.method = c("es.max"), 
+#              estimand = "ATE", verbose = FALSE, n.trees = 1000)
+# bal.tab(ps.out, int = T)
+# 
+# 
+# 
+# #love.plot
+# v <- data.frame(old = c("age", "educ", "race_black", "race_hispan", 
+#                         "race_white", "married", "nodegree", "re74", "re75", "distance"),
+#                 new = c("Age", "Years of Education", "Black", 
+#                         "Hispanic", "White", "Married", "No Degree Earned", 
+#                         "Earnings 1974", "Earnings 1975", "Propensity Score"))
+# plot(bal.tab(m1), threshold = .1, var.names = v)
+# love.plot(m1, stat = c("m", "v"), stars = "std", drop.distance = T)
+# 
+# love.plot(bal.tab(m1, cluster = lalonde$school), stat = "ks", agg.fun = "range", which.cluster = NA)
+# love.plot(cbps.out2.e, drop.distance = F, line = T, abs = T,
+#           var.order = "u")
+# love.plot(bal.tab(f.build("treat", covs_mis), data = imp.data, weights = "match.weight", 
+#                   method = "matching", imp = ".imp", distance = "ps"),
+#           agg.fun = "range")
+# love.plot(f.build("treat", covs_mis), data = imp.data, weights = "match.weight", 
+#           method = "matching", imp = ".imp", distance = "ps",
+#           cluster = "race", which.cluster = 1:3,
+#           agg.fun = "range", stat = c("m", "ks"))
+# #bal.plot
+# bal.plot(m1, "age", which = "both")
+# bal.plot(m1, "race")
+# bal.plot(cbps.out, "age", mirror = TRUE, type = "h", bins = 20, colors = c("white", "black"))
+# bal.plot(cbps.out, "race", which = "both")
+# bal.plot(cbps.out2, "age", which = "both")
+# bal.plot(cbps.out2, "race", which = "u")
+# bal.plot(m3, "age", which.sub = 2)
+# bal.plot(m3, "race", which.sub = 1:3, which = "both")
+# bal.plot(m5, "age", cluster = lalonde$school, which.cluster = c("A", "B"), which = "both")
+# bal.plot(m5, "race", cluster = lalonde$school, which.cluster = .none)
+# bal.plot(cbps.out2, "age", cluster = lalonde$school, which.cluster = c("A", "B"), which = "both")
+# bal.plot(cbps.out2, "race", cluster = lalonde$school)
+# bal.plot(f.build("treat", covs_mis), data = imp.data, weights = "match.weight", 
+#          method = "matching", imp = ".imp", var.name = "age", which = "b")
+# bal.plot(f.build("treat", covs_mis), data = imp.data, weights = "match.weight", 
+#          method = "matching", imp = ".imp", cluster = "race", which.imp = 1,
+#          var.name = "age", which = "b")
+# 
+# #Other packages
+# 
+# #ATE
+# library("ATE")
+# ate.att <- ATE(Y = lalonde_$re78, lalonde_$treat, covs_, ATT = T)
+# ate.att$weights.q[lalonde$treat == 1] <- 1
+# bal.tab(covs, lalonde$treat, weights = ate.att$weights.q, method = "w", estimand = "att", disp.v.ratio = T)
+# 
+# ate.ate <- ATE(Y = rep(0, nrow(lalonde)), lalonde_$treat, covs_, ATT = F, theta = 1)
+# ate.ate$weights <- ate.ate$weights.q + ate.ate$weights.p
+# bal.tab(covs, lalonde$treat, weights = ate.ate$weights, method = "w", estimand = "ate", disp.v.ratio = T)
+# 
+# #CMatching
+# library("CMatching")
+# lalonde$school <- sample(1:2, nrow(lalonde), replace = T)
+# ls <- lalonde[order(lalonde$school),]
+# p.score <- glm(treat ~ age + educ + race + married + nodegree + re74 + re75 + factor(school) - 1, 
+#                data = ls, family = "binomial")$fitted.values
+# MW <- MatchPW(Tr = ls$treat, X = p.score,
+#               M = 1, replace = T, Group = ls$school,
+#               caliper = 2, estimand = "ATT")
+# bal.tab(MW, formula = f.build("treat", covs), data = ls, cluster = "school")
+# 
+# #designmatch
+# library(designmatch)
+# ls <- lalonde[order(lalonde$treat, decreasing = T),]
+# cs <- covs[order(lalonde$treat, decreasing = T),]
+# dmout <- bmatch(ls$treat,
+#                 dist_mat = NULL,
+#                 subset_weight = 1,
+#                 total_groups = 100,
+#                 mom = list(covs = as.matrix(cs[-(3:5)]),
+#                            tols = absstddif(as.matrix(cs[-(3:5)]), ls$treat, .0001)),
+#                 # ks = list(covs = as.matrix(covs_[-c(3:7)]), 
+#                 #           n_grid = 7,
+#                 #            tols = rep(.05, 4)),
+#                 n_controls = 1,
+#                 solver = list(name = "glpk", approximate = 1)
+#                 # , total_groups = 185
+#                 , fine = list(covs = cs[c(3,4,5)])
+# )
+# 
+# bal.tab(dmout, covs = cs, treat = ls$treat)
+# bal.tab(dmout, formula = treat ~ covs, data = ls)
+# 
+# #optweight (default method)
+# library(optweight)
+# W <- optweight(f.build("treat", covs), data = lalonde,
+#                estimand = "ATT")
+# bal.tab(W)
+# W.cont <- optweight(f.build("re75", covs[-7]), data = lalonde)
+# bal.tab(W.cont)
+# W.mult <- optweight(f.build("race", covs[-3]), data = lalonde,
+#                     estimand = "ATE",
+#                     focal = "black")
+# bal.tab(W.mult)
+# 
+# #Multinomial
+# lalonde$treat3 <- factor(ifelse(lalonde$treat == 1, "A", sample(c("B", "C"), nrow(lalonde), T)))
+# bal.tab(f.build("treat3", covs), data = lalonde, focal = 1, which.treat = 1:3, m.threshold = .1)
+# mnps3.out <- mnps(f.build("treat3", covs), data = lalonde, 
+#                   stop.method = c("es.mean", "es.max"), 
+#                   estimand = "ATE", verbose = FALSE,
+#                   n.trees = 200)
+# bal.tab(mnps3.out, which.treat = 1:3)
+# bal.plot(mnps3.out, var.name = "age")
+# mnps3.att <- mnps(f.build("treat3", covs), data = lalonde, 
+#                   stop.method = c("ks.max"), 
+#                   estimand = "ATT", verbose = FALSE,
+#                   treatATT = "B")
+# bal.tab(mnps3.att, which.treat = .all)
+# bal.plot(mnps3.att, var.name = "age")
+# cbps.out3 <- CBPS(f.build("treat3", covs), data = lalonde)
+# bal.tab(cbps.out3)
+# bal.plot(cbps.out3, var.name = "age")
+# bal.plot(f.build("treat3", covs), data = lalonde, var.name = "age",
+#          weights = list((cbps.out3),
+#                         (mnps3.out)),
+#          method = "w", which = "both")
+# bal.tab(f.build("treat3", covs), data = lalonde, 
+#         weights = data.frame(cbps = get.w(cbps.out3),
+#                              gbm = get.w(mnps3.out)),
+#         method = "w")
+# ate3.out <- ATE(rep(0, nrow(lalonde)), as.numeric(lalonde$treat3)-1,
+#                 covs_, ATT = TRUE)
+# ate3.out$weights <- apply(ate3.out$weights.mat, 2, sum)
+# bal.plot(f.build("treat3", covs), data = lalonde, var.name = "age",
+#          weights = data.frame(ate = ate3.out$weights),
+#          method = "w", which = "both")
+# bal.tab(f.build("treat3", covs), data = lalonde,
+#         weights = data.frame(ate = ate3.out$weights),
+#         method = "w")
+# #MSMs
+# library("twang")
+# data(iptwExWide, package = "twang")
+# bal.tab(list(iptwExWide[c("use0", "gender", "age")], iptwExWide[c("use0", "gender", "age", "use1", "tx1")]), treat.list = iptwExWide[c("tx1", "tx2")])
+# bal.tab(list(tx1 ~ use0 + gender + age,
+#              tx2 ~ use1 + use0 + tx1 + gender + age,
+#              tx3 ~ use2 + use1 + use0 + tx2 + tx1 + gender + age),
+#         data = iptwExWide)
+# 
+# iptw.Ex <- iptw(list(tx1 ~ use0 + gender + age,
+#                      tx2 ~ use1 + use0 + tx1 + gender + age,
+#                      tx3 ~ use2 + use1 + use0 + tx2 + tx1 + gender + age),
+#                 timeInvariant ~ gender + age,
+#                 data = iptwExWide,
+#                 cumulative = FALSE,
+#                 priorTreatment = FALSE,
+#                 verbose = FALSE,
+#                 stop.method = "es.max",
+#                 n.trees = 2000)
+# bal.tab(iptw.Ex)
+# data("iptwExLong")
+# iptw.l <- iptw(tx ~ gender + age + use, data = iptwExLong$covariates, 
+#                timeIndicators = iptwExLong$covariates$time, ID = iptwExLong$covariates$ID,
+#                n.trees = 200, stop.method = "es.max",
+#                verbose = FALSE)
+# bal.tab(iptw.l)
+# 
+# library("WeightIt")
+# Wmsm <- weightitMSM(list(tx1 ~ use0 + gender + age,
+#                          tx2 ~ use1 + use0 + tx1 + gender + age,
+#                          tx3 ~ use2 + use1 + use0 + tx2 + tx1 + gender + age),
+#                     data = iptwExWide,
+#                     method = "ps")
+# bal.tab(Wmsm)
+# 
+# library("CBPS")
+# data(iptwExLong, package = "twang")
+# cbps.msm <- CBMSM(tx ~ age + use,
+#                   data = iptwExLong$covariates,
+#                   id = iptwExLong$covariates$ID,
+#                   time = iptwExLong$covariates$time,
+#                   time.vary = T, msm.variance = "full")
+# bal.tab(cbps.msm)
+# W.msm <- weightitMSM(list(tx1 ~ use0 + gender + age,
+#                           tx2 ~ use1 + use0 + tx1 + gender + age,
+#                           tx3 ~ use2 + use1 + use0 + tx2 + tx1 + gender + age),
+#                      data = iptwExWide, stabilize = F,
+#                      verbose = FALSE,
+#                      method = "ps")
+# bal.tab(W.msm)
+# 
+# #Target checking
+# library(WeightIt)
+# w1 <- weightit(lalonde$treat ~ covs, estimand = "ATE")
+# target.bal.tab(w1, which.treat = NULL)
+# 
+# w2 <- weightit(lalonde$race ~ covs[-3], estimand = "ATE", method = "cbps")
+# target.bal.tab(w2, which.treat = NULL)
+# 
+# w3 <- weightit(lalonde$re78 ~ covs, estimand = "ATE", method = "cbps", over = FALSE)
+# target.bal.tab(w3, which.treat = NULL)
+# target.bal.tab(w3, disp.means = T, int = 2, imbalanced.only = T, v.threshold = .5)
+# 
+# w4 <- weightitMSM(list(tx1 ~ use0 + gender + age,
+#                        tx2 ~ use1 + use0 + tx1 + gender + age,
+#                        tx3 ~ use2 + use1 + use0 + tx2 + tx1 + gender + age),
+#                   data = iptwExWide,
+#                   verbose = FALSE,
+#                   method = "ps")
+# target.bal.tab(w4, which.treat = NULL)
+# 
+# 
+# a <- function() {
+#     d <- lalonde
+#     lapply(1:3, function(i) {
+#         lapply(1, function(x) {
+#             b <- do.call(bal.tab, list(f.build("treat",covs), data = d, cluster = "race", which.cluster = NULL), quote = T)
+#         })
+#     })
+# }

--- a/tests/testthat/test-bal.tab.R
+++ b/tests/testthat/test-bal.tab.R
@@ -1,0 +1,105 @@
+covs <- subset(lalonde, select = -c(re78, treat))
+lalonde_ <- splitfactor(lalonde, "race", drop.first = F)
+covs_ <- subset(lalonde_, select = -c(re78, treat))
+
+test_that("No adjustment", {
+    data("lalonde", package = "cobalt")
+    
+    expect_snapshot(
+        bal.tab(
+            covs,
+            treat = lalonde$treat,
+            m.threshold = .1,
+            v.threshold = 2,
+            imbalanced.only = T
+        )
+    )
+    expect_snapshot(bal.tab(
+        f.build("treat", covs),
+        data = lalonde,
+        ks.threshold = .1
+    ))
+})
+
+test_that("MatchIt with PS", {
+    skip_if_not_installed("MatchIt")
+    m1 <- MatchIt::matchit(
+            treat ~ log(age) * married + educ + race + nodegree + re74 + re75,
+            data = lalonde,
+            replace = T,
+            ratio = 2,
+            discard = "both",
+            reestimate = TRUE
+        )
+    expect_snapshot(
+        bal.tab(
+            m1,
+            int = T,
+            v.threshold = 2,
+            imbalanced.only = F
+        )
+    )
+})
+
+test_that("MatchIt with distance", {
+    skip_if_not_installed("MatchIt")
+    set.seed(123)
+    m1.1 <- MatchIt::matchit(
+        f.build("treat", covs),
+        data = lalonde,
+        distance = runif(nrow(lalonde))
+    )
+    expect_snapshot(bal.tab(m1.1, data = lalonde))
+})
+
+test_that("MatchIt with complicated formula", {
+    skip_if_not_installed("MatchIt")
+    skip_if_not_installed("rms")
+    m1.2 <- MatchIt::matchit(
+        treat ~ log(age)*married + poly(educ,2) + rms::rcs(age,3) + race + factor(nodegree) + re74 + re75, 
+        data = lalonde, 
+        replace = T, 
+        ratio = 2
+    )
+    
+    expect_snapshot(bal.tab(m1.2, addl = ~ rms::rcs(educ,3) + poly(age,2)))
+})
+
+test_that("MatchIt with Malahanobis", {
+    skip_if_not_installed("MatchIt")
+    m2 <- MatchIt::matchit(f.build("treat", covs), data = lalonde, distance = "mahalanobis")
+    
+    expect_snapshot(
+        bal.tab(m2, data = lalonde, int = T, v.threshold = 2, addl = "race")
+    )
+})
+
+test_that("MatchIt with subclassification", {
+    skip_if_not_installed("MatchIt")
+    m3 <- MatchIt::matchit(f.build("treat", covs), data = lalonde, method = "subclass")
+    
+    expect_snapshot(
+        bal.tab(m3, int = F, v.threshold = 2, disp.subclass = T, ks.threshold = .1)
+    )
+})
+
+test_that("MatchIt: full matching", {
+    skip_if_not_installed("MatchIt")
+    m4 <- MatchIt::matchit(f.build("treat", covs), data = lalonde, method = "full", distance = "glm", link = "probit", estimand = "ATE")
+    expect_snapshot(
+        bal.tab(m4, int = T, ks.threshold = .05)
+    )
+    expect_snapshot(
+        bal.tab(m4, pairwise = FALSE, un = T)
+    )
+})
+
+test_that("MatchIt: genetic matching, using matching weights", {
+    skip_if_not_installed("MatchIt")
+    skip_if_not_installed("rgenoud")
+    m5 <- MatchIt::matchit(f.build("treat", covs), data = lalonde, method = "genetic", replace = F,
+                  ratio = 1, pop.size = 50)
+   expect_snapshot(
+       bal.tab(m5, method = "m", estimand = "ATT")
+   )
+})


### PR DESCRIPTION
Hello @ngreifer, the goal of this PR is to convert the tests that are in `do_not_include/tests.R` to `testthat`, so that the testing process is more robust and more transparent about the expected outcome (related to #5). Indeed, unless I'm mistaken (which may completely be the case), you don't really test that outputs stay the same in `do_not_include/tests.R`.

I just converted a few tests so that you can let me know what you think. If you agree with this conversion, then I can go on and move the rest of the tests.

The "problem" is that `bal.tab()` shows quite a lot of information and it would be tedious to hardcode all expected output to check that the results don't change, so I used snapshot testing. If you're not familiar with this, it consists in saving the output of `bal.tab()` to a text file (contained in `tests/testthat/_snaps`) and this output will serve as a reference for the future checks. This means that if anything changes in the output of `bal.tab()` (including the formatting such as spaces, indents, etc.), you will be notified and you can then review the changes (and potentially accept them). Here are some slides about it if you're interested: https://indrajeetpatil.github.io/intro-to-snapshot-testing/#/title-slide

Anyway, let me know first if you want to continue this transition towards `testthat`

Thanks for this super useful package ;)