### PR TITLE
Update `love.plot` to be compatible with upcoming ggplot2 version

### DIFF
--- a/R/love.plot.R
+++ b/R/love.plot.R
@@ -1164,7 +1164,14 @@ love.plot <- function(x, stats, abs, agg.fun = NULL,
             else legend.to.get <- 1
             
             legg <- ggplot2::ggplotGrob(plots.to.combine[[legend.to.get]] + ggplot2::theme(legend.position = position))
-            leg <- legg$grobs[[which(legg$layout$name == "guide-box")]]
+            if (any(legg$layout$name == "guide-box")) {
+                leg <- legg$grobs[[which(legg$layout$name == "guide-box")]]
+            } else if (any(legg$layout$name == paste0("guide-box-", position))) {
+                # ggplot2 >=3.5.0 can have multiple legends
+                leg <- legg$grobs[[which(legg$layout$name == paste0("guide-box-", position))]]
+            } else {
+                position <- "none"
+            }
             
             if (position == "left") {
                 p <- gridExtra::arrangeGrob(grobs = list(leg, g), nrow = 1, 


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break cobalt.

In the next version, a plot can have legends at multiple locations. This goes against the expectation in `love.plot()` that there is one, and only one, legend per plot. This PR updates `love.plot()` to deal with the new legend structure in ggplot2.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of Februari. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help cobalt get out a fix if necessary.